### PR TITLE
don't give up the build directory search too early

### DIFF
--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -151,10 +151,6 @@ For example:
     (setq cppcm-build-dir nil)
     (setq cppcm-src-dir nil)
     (catch 'brk
-           ; if current directory does not contain CMakeLists.txt, we assume the
-           ; whole project does not use cmake at all
-           (if (not (file-exists-p (concat crt-proj-dir "CMakeLists.txt"))) (throw 'brk nil))
-
            (while (and (< i cppcm-proj-max-dir-level) (not is-root-dir-found) )
                   (setq cppcm-build-dir (concat crt-proj-dir (file-name-as-directory cppcm-build-dirname)))
                   (cond ((and (file-exists-p (concat cppcm-build-dir "CMakeCache.txt")))


### PR DESCRIPTION
The current code works great if you have a simple project. When it grows into several subdirectories like src/client/ui, the early check for a CMakeLists.txt stops us from finding the correct build directory.
