### PR TITLE
Remove trailing dot from package description to match conventions

### DIFF
--- a/cpputils-cmake-pkg.el
+++ b/cpputils-cmake-pkg.el
@@ -1,2 +1,2 @@
 (define-package "cpputils-cmake" "0.4.5"
-                "Easy real time C++ syntax check and intellisense if you use CMake.")
+                "Easy real time C++ syntax check and intellisense if you use CMake")


### PR DESCRIPTION
In connection with https://github.com/milkypostman/melpa/pull/1548
