### PR TITLE
Fix bug when CXX_FLAGS contains an option with length less than 2 (ie -g)

### DIFF
--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -331,7 +331,7 @@ White space here is any of: space, tab, emacs newline (line feed, ASCII 10)."
     ;; rebuild the arguments in one string, append double quote string
     (dolist (tk tks v)
       (cond
-       ((string= (substring tk 0 2) "-I")
+       ((and (> (length tk) 1) (string= (substring tk 0 2)) "-I")
         (setq v (concat v " -I\"" (substring tk 2 (length tk)) "\"")))
 
        ((string= (substring tk 0 1) "I")


### PR DESCRIPTION
On a project I am working I had on CMakeLists.txt:

```
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -Wall -Wextra -pedantic -Werror")
```

and since the option -g has lenght less than 2, the `(substring tk 0 2)` failed, causing `cpputils-cmake` to report a very confusing error: "Failed to create Makefile for flymake. Continue anyway." and not working. I traced the source of the problem to be the parameter `-g` and the proposed change fixed the issue.
