### PR TITLE
Tell irony where to find compile_commands.json

### DIFF
--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -755,7 +755,7 @@ by customize `cppcm-compile-list'."
     (if cppcm-debug (message "company-c-headers-path-system=%s" company-c-headers-path-system))
 
     ;; irony compile-commands-path
-    (irony-cdb-json-add-compile-commands-path (cppcm-src-dir (concat (cppcm-build-dir "compile_commands.json"))))
+    (irony-cdb-json-add-compile-commands-path cppcm-src-dir '(concat (cppcm-build-dir "compile_commands.json")))
 
     ;; set cc-search-directories automatically, so ff-find-other-file will succeed
     (add-hook 'ff-pre-find-hook

--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -754,6 +754,9 @@ by customize `cppcm-compile-list'."
     (setq company-c-headers-path-system flycheck-clang-include-path)
     (if cppcm-debug (message "company-c-headers-path-system=%s" company-c-headers-path-system))
 
+    ;; irony compile-commands-path
+    (irony-cdb-json-add-compile-commands-path (cppcm-src-dir (concat (cppcm-build-dir "compile_commands.json"))))
+
     ;; set cc-search-directories automatically, so ff-find-other-file will succeed
     (add-hook 'ff-pre-find-hook
               '(lambda ()

--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -755,7 +755,8 @@ by customize `cppcm-compile-list'."
     (if cppcm-debug (message "company-c-headers-path-system=%s" company-c-headers-path-system))
 
     ;; irony compile-commands-path
-    (irony-cdb-json-add-compile-commands-path cppcm-src-dir '(concat (cppcm-build-dir "compile_commands.json")))
+    (if (fboundp 'irony-cdb-json-add-compile-commands-path)
+        (irony-cdb-json-add-compile-commands-path cppcm-src-dir (concat cppcm-build-dir "compile_commands.json")))
 
     ;; set cc-search-directories automatically, so ff-find-other-file will succeed
     (add-hook 'ff-pre-find-hook


### PR DESCRIPTION
CMake can output a compile_commands.json file which tells irony-mode how everything is compiled. By default irony wants to find the file in the src root directory. This change tells irony to look inside the cmake build directory.