### PR TITLE
remove previous semantic includes instead of resetting

### DIFF
--- a/cpputils-cmake.el
+++ b/cpputils-cmake.el
@@ -767,13 +767,16 @@ by customize `cppcm-compile-list'."
     (if cppcm-debug (message "company-clang-arguments=%s" company-clang-arguments))
 
     (when (fboundp 'semantic-add-system-include)
-      (semantic-reset-system-include)
-      (mapcar 'semantic-add-system-include
-              (delq nil
-                    (mapcar (lambda (str)
-                              (if (string-match "^-I *" str)
-                                  (replace-regexp-in-string "^-I *" "" str)))
-                            ac-clang-flags))))
+      (let ((dirs
+             (delq nil
+                   (mapcar (lambda (str)
+                             (if (string-match "^-I *" str)
+                                 (replace-regexp-in-string "^-I *" "" str)))
+                           ac-clang-flags))))
+        (when (boundp 'cppcm-semantic-system-include)
+          (mapcar 'semantic-remove-system-include cppcm-semantic-system-include))
+        (mapcar 'semantic-add-system-include dirs)
+        (setq-local cppcm-semantic-system-include dirs)))
 
     ;; unlike auto-complete and company-mode, flycheck prefer make things complicated
     (setq flycheck-clang-include-path (delq nil


### PR DESCRIPTION
`(semantic-reset-system-include)` Removes all paths including /usr/include and the ones from `semantic-gcc-setup`, which was causing me to lose parsing of system headers.  This change stores the paths added by cppcm and removes them on the next reload.  I've tested removing paths from cmake, calling reload-all, and it all seems to work as expected, but this hasn't been extensively tested yet.